### PR TITLE
Updating dependencies and moving dependencies that were only used in the...

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,14 @@
   "dependencies": {
     "cuid": "~1.2.1",
     "bunyan": "~0.21.4",
-    "express": "~3.4.0",
-    "mout": "~0.7.1",
-    "express-error-handler": "~0.5.1"
+    "mout": "~0.7.1"
   },
   "devDependencies": {
     "connect-cache-control": "~0.1.0",
-    "express-error-handler": "~0.1.1",
+    "express-error-handler": "~0.5.1",
     "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.6.4"
+    "express": "~4.9.8",
+    "grunt-contrib-jshint": "~0.10.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Updating dependencies and moving dependencies that were only used in the examples into devDependencies.
The version of express that was being used had dependencies that contained security vulnerabilties

Fixes https://github.com/ericelliott/bunyan-request-logger/issues/5

Note: examples/app.js will now emit a deprecation warning:

```
Wed, 22 Oct 2014 13:55:30 GMT express deprecated res.send(status): Use res.status(status).end() instead at ../node_modules/express-error-handler/error-handler.js:237:19
```

This is because [express-error-handler](https://github.com/ericelliott/express-error-handler) is not compatible with express 4.x but I suspect that will be fixed at version 0.6.0
