### PR TITLE
Adding first tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,19 +7,23 @@
     "example": "examples"
   },
   "dependencies": {
-    "cuid": "~1.2.1",
     "bunyan": "~0.21.4",
+    "cuid": "~1.2.1",
     "mout": "^0.11.0"
   },
   "devDependencies": {
     "connect-cache-control": "~0.1.0",
+    "express": "^4.11.2",
     "express-error-handler": "~0.6.0",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.10.0",
-    "express": "^4.11.2"
+    "mocha": "~2.1.0",
+    "should": "~4.6.5",
+    "sinon": "~1.12.2",
+    "supertest": "~0.15.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --recursive --reporter spec ./test"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,218 @@
+var sinon = require('sinon');
+var bunyan = require('bunyan');
+var logger = require('../request-logger.js');
+var express = require('express');
+var request = require('supertest');
+var should = require('should');
+var errorHandler = require('express-error-handler');
+
+
+/**
+ * Creates a default app that uses the request logger and has an endpoint
+ * at /something that should return a 200 OK
+ * and an error endpoint that throws a new error.
+ * The app uses express-error-handler so that 404 become errors and are captured
+ * in the error log.
+ */
+function createDefaultApp(loggerOptions) {
+  var log = logger(loggerOptions);
+  var app = express();
+
+  app.use(log.requestLogger());
+
+
+  app.get('/something', function returnSomething(req, res) {
+    res.send('Hello World!')
+  });
+
+  // Route that triggers a sample error:
+  app.get('/error', function createError() {
+    throw new Error('Sample error');
+  });
+
+  app.use(errorHandler.httpError(404));
+
+  // Log request errors:
+  app.use(log.errorLogger());
+
+  return app;
+}
+
+describe('bunyan-request-logger', function () {
+  var infoSpy;
+  var errorSpy;
+  var app = createDefaultApp({level: bunyan.FATAL});
+
+  before(function () {
+    infoSpy = sinon.spy(bunyan.prototype, 'info');
+    errorSpy = sinon.spy(bunyan.prototype, 'error');
+
+    // hide console errors while running the tests
+    sinon.stub(console, 'error');
+  });
+
+  beforeEach(function () {
+    infoSpy.reset();
+    errorSpy.reset();
+  });
+
+  after(function () {
+    infoSpy.restore();
+    console.error.restore();
+  });
+
+  describe('info logging', function () {
+
+    it('should call info twice per request', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          infoSpy.calledTwice.should.be.true;
+          done();
+        })
+    });
+
+    it('should call info twice per request that returns HTTP 500 error', function (done) {
+      request(app)
+        .get('/error')
+        .end(function (err) {
+          should.not.exist(err);
+
+          infoSpy.calledTwice.should.be.true;
+          done();
+        })
+    });
+
+    it('should call info twice per request that returns a HTTP 404 not found', function (done) {
+      request(app)
+        .get('/does.not.exist')
+        .end(function (err) {
+          should.not.exist(err);
+
+          infoSpy.calledTwice.should.be.true;
+          done();
+        })
+    });
+
+
+    it('should log the response at the info level', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var logInfoMetadata = infoSpy.secondCall.args[0];
+          logInfoMetadata.should.have.properties('res');
+          done();
+        })
+    });
+
+    it('should log the response time at the info level', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var logInfoMetadata = infoSpy.secondCall.args[0];
+          logInfoMetadata.res.responseTime.should.be.a.Number;
+          (logInfoMetadata.res.responseTime >= 0).should.be.true;
+          done();
+        })
+    });
+
+    it('should log the request id in the response at the info level', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var logInfoMetadata = infoSpy.secondCall.args[0];
+          logInfoMetadata.res.requestId.should.be.a.String;
+          logInfoMetadata.res.requestId.should.not.be.empty;
+          done();
+        })
+    });
+
+    it('should log the request at the info level', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var logInfoMetadata = infoSpy.firstCall.args[0];
+          logInfoMetadata.should.have.keys('req');
+          done();
+        })
+    });
+
+    it('should log the request id at the info level', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var logInfoMetadata = infoSpy.firstCall.args[0];
+          logInfoMetadata.req.requestId.should.be.a.String;
+          logInfoMetadata.req.requestId.should.not.be.empty;
+
+          done();
+        })
+    });
+
+    it('should log the same request id for the request and response', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var reqMetadata = infoSpy.firstCall.args[0];
+          var resMetadata = infoSpy.secondCall.args[0];
+          reqMetadata.req.requestId.should.equal(resMetadata.res.requestId);
+
+          done();
+        })
+    });
+  });
+
+  describe('error logging', function () {
+    it('should not call error on a simple request', function (done) {
+
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          errorSpy.called.should.be.false;
+          done();
+        })
+    });
+
+    it('should call error once on a error on an endpoint that returns 500', function (done) {
+      request(app)
+        .get('/error')
+        .end(function (err) {
+          should.not.exist(err);
+
+          errorSpy.calledOnce.should.be.true;
+          done();
+        })
+    });
+
+    it('should call error once on a error on a 404 when using error handler', function (done) {
+      request(app)
+        .get('/this.does.not.exist')
+        .end(function (err) {
+          should.not.exist(err);
+
+          errorSpy.calledOnce.should.be.true;
+          done();
+        })
+    });
+  });
+
+
+});
+
+exports.createDefaultApp = createDefaultApp;

--- a/test/serializers.js
+++ b/test/serializers.js
@@ -1,0 +1,137 @@
+var sinon = require('sinon');
+var bunyan = require('bunyan');
+var request = require('supertest');
+var should = require('should');
+var createDefaultApp = require('./').createDefaultApp;
+
+var app = createDefaultApp();
+
+describe('bunyan-request-logger serializers', function () {
+  var emitSpy;
+
+  before(function () {
+    // we spy the emit function to know what is being sent in there after serializing
+    emitSpy = sinon.stub(bunyan.prototype, '_emit');
+
+    // hiding error output that comes from throwing errors around in our tests
+    sinon.stub(console, 'error');
+
+  });
+
+  beforeEach(function(){
+    emitSpy.reset();
+  });
+
+  after(function () {
+    emitSpy.restore();
+    console.error.restore();
+  });
+
+  describe('res serializer', function () {
+
+    it('should log the correct properties when logging the response', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var emitArgs = emitSpy.secondCall.args[0];
+          //will fail if there are extra properties
+          emitArgs.should.have.keys('hostname', 'level', 'msg', 'name', 'pid', 'level', 'res', 'time', 'v');
+          done();
+        })
+    });
+
+
+    it('should log the correct properties for the res object when logging the response', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var emitArgs = emitSpy.secondCall.args[0];
+
+          // will fail if there are extra properties
+          emitArgs.res.should.have.keys('statusCode', 'headers', 'requestId', 'responseTime');
+          done();
+        })
+    });
+  });
+
+
+  describe('res serializer', function () {
+
+    it('should log the correct properties when logging the response', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var emitArgs = emitSpy.firstCall.args[0];
+          // will fail if there are extra properties
+          emitArgs.should.have.keys('hostname', 'level', 'msg', 'name', 'pid', 'level', 'req', 'time', 'v');
+          done();
+        })
+    });
+
+
+    it('should log the correct properties for the req object when logging the response', function (done) {
+      request(app)
+        .get('/something')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var emitArgs = emitSpy.firstCall.args[0];
+          // will fail if there are extra properties
+          emitArgs.req.should.have.keys('headers', 'requestId', 'url', 'method', 'protocol', 'ip');
+          done();
+        })
+    });
+  });
+
+  describe('err serializer', function () {
+
+    it('should log the correct properties when logging the response', function (done) {
+      request(app)
+        .get('/error')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var emitArgs = emitSpy.secondCall.args[0];
+          // will fail if there are extra properties
+          emitArgs.should.have.keys('hostname', 'level', 'msg', 'name', 'pid', 'level', 'err', 'time', 'v');
+          done();
+        })
+    });
+
+
+    it('should log the correct properties for the err object when logging the response', function (done) {
+      request(app)
+        .get('/error')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var emitArgs = emitSpy.secondCall.args[0];
+          // will fail if there are extra properties
+          emitArgs.err.should.have.keys('message', 'name', 'stack', 'code', 'signal', 'requestId');
+          done();
+        })
+    });
+
+    it('should not log the stack on 4xx errors', function (done) {
+      request(app)
+        .get('/this.does.not.exist')
+        .end(function (err) {
+          should.not.exist(err);
+
+          var emitArgs = emitSpy.secondCall.args[0];
+          // will fail if there are extra properties
+          emitArgs.err.should.not.have.properties('stack');
+          done();
+        })
+    });
+
+
+  });
+
+});


### PR DESCRIPTION
This is the first piece of work for issue https://github.com/ericelliott/bunyan-request-logger/issues/7

Adding some simple tests to quickly see if  something is horribly broke. It basically checks if the log functions are being called. Also added some tests to see if the correct information is being serialized before being emitted.

I think this is a pretty good first step.

Used sinon for spying on and stubbing function.
Used mocha as a test framework.
Using should for test assertions.
Using supertest to create fake http requests.