### PR TITLE
Update bunyan so it works with babel-node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "examples"
   },
   "dependencies": {
-    "bunyan": "~1.3.4",
+    "bunyan": "~1.5.1",
     "cuid": "~1.2.4",
     "lodash": "^3.3.1"
   },


### PR DESCRIPTION
with the old bunyan I've been having errors when running `babel-node` but it is fixed in the latest version.

```
/var/repositories/universal-react-boilerplate/node_modules/bunyan-request-logger/node_modules/bunyan/lib/bunyan.js:1348
module.exports.RotatingFileStream = RotatingFileStream;
                                    ^
ReferenceError: RotatingFileStream is not defined
    at Object.<anonymous> (/var/repositories/universal-react-boilerplate/node_modules/bunyan-request-logger/node_modules/bunyan/lib/bunyan.js:1429:37)
    at Module._compile (module.js:460:26)
    at normalLoader (/var/repositories/universal-react-boilerplate/node_modules/babel-core/lib/api/register/node.js:199:5)
    at Object.require.extensions.(anonymous function) [as .js] (/var/repositories/universal-react-boilerplate/node_modules/babel-core/lib/api/register/node.js:216:7)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/var/repositories/universal-react-boilerplate/node_modules/bunyan-request-logger/request-logger.js:5:12)
    at Module._compile (module.js:460:26)
```