### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm install --save bunyan-request-logger
 'use strict';
 
 var express = require('express'),
-  logger = require('../request-logger.js'),
+  logger = require('bunyan-request-logger'),
   noCache = require('connect-cache-control'),
   log = logger(),
   app = express(),

--- a/examples/app.js
+++ b/examples/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var express = require('express'),
-  logger = require('../request-logger.js'),
+  logger = require('../request-logger.js'), //use 'bunyan-request-logger' in your code
   noCache = require('connect-cache-control'),
   errorHandler = require('express-error-handler'),
   log = logger(),

--- a/examples/log-only.js
+++ b/examples/log-only.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var express = require('express'),
-  logger = require('../request-logger.js'),
+  logger = require('../request-logger.js'),  //use 'bunyan-request-logger' in your code
   noCache = require('connect-cache-control'),
   log = logger(),
   app = express(),


### PR DESCRIPTION
require 'bunyan-request-logger' vs 'request-logger' because request-logger is another express middleware, which can result in confusion