### PR TITLE
Enabling automatic testing through travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "stable"
+  - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "stable"
+  - "4.2"
   - "0.12"


### PR DESCRIPTION
Adding a travis file so that we can have automatic testing.

This should be sufficient. Travis uses ```npm test``` by default.

However, I don't have admin access to this repo so I cannot enable the travis build on it. @ericelliott should be able to so by going to https://travis-ci.org/profile