### PR TITLE
Refactor: remove redundant check

### DIFF
--- a/request-logger.js
+++ b/request-logger.js
@@ -19,8 +19,7 @@ var
     var ret = err.stack || err.toString(),
       cause;
 
-    if (err.cause && typeof (err.cause) ===
-        'function') {
+    if (typeof err.cause === 'function') {
       cause = err.cause();
       if (cause) {
         ret += '\nCaused by: ' +


### PR DESCRIPTION
Check for `err.cause` is redundant, because `typeof null === 'object'` and `typeof undefined === 'undefined'`